### PR TITLE
Publish without /dist/ in the package

### DIFF
--- a/package.json.template
+++ b/package.json.template
@@ -1,6 +1,6 @@
 {
   "name": "eccentric-engine",
-  "version": "1.0.0",
+  "version": "##VERSION",
   "description": "A simple engine for Javascript games",
   "main": "Engine.js",
   "dependencies": {
@@ -19,8 +19,8 @@
     "build-prod": "webpack --config webpack.prod.js"
   },
   "files": [
-    "dist/Engine.js",
-    "dist/Engine.js.map"
+    "Engine.js",
+    "Engine.js.map"
   ],
   "repository": {
     "type": "git",

--- a/release.sh
+++ b/release.sh
@@ -1,10 +1,41 @@
 #!/bin/bash
 
-echo 'clearing /dist'
+USAGE="release.sh -v version [-t tag]"
+TAG=""
+PWD=$(pwd)
+
+# validate expected parameters
+while getopts ":v:t:" opt; do
+  case $opt in
+    v) VERSION="$OPTARG"
+    ;;
+    t) TAG="--tag $OPTARG"
+    ;;
+    \?) echo $USAGE
+    ;;
+  esac
+done
+
+echo "clearing /dist"
 rm -rf dist
 
-echo 'building for release...'
+echo "setting version to $VERSION"
+sed 's/##VERSION/'"$VERSION"'/g' $PWD/package.json.template > $PWD/package.json
+
+echo "building for release..."
 npm run build-prod
-echo 'done!'
-echo ''
-echo 'you can now run "npm publish [--tag beta] [--dry-run]"'
+echo "done!"
+echo ""
+echo "setting up for publish..."
+mv $PWD/package.json $PWD/dist/package.json
+echo ""
+
+echo "switching to /dist"
+cd $PWD/dist
+
+echo "publishing..."
+npm publish $TAG
+
+cd $PWD
+
+# echo "done!"


### PR DESCRIPTION
It's hacky but seemed to work: 
`release.sh -v version [-t tag]` builds the `package.json` from a template, runs the build script, moves `package.json` into the `/dist` directory, and runs `npm publish` from there.

The end result should be that you can now run
`npm install eccentric-engine`
and
`import { Engine } from 'eccentric-engine/Engine';` 
in your game project.
